### PR TITLE
Handle Windows Filepaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "chalk": "^1.1.3",
-    "event-stream": "^3.3.4",
+    "event-stream": "^4.0.1",
     "gulp-util": "^3.0.7",
     "map-stream": "0.0.6",
     "through2": "^2.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,10 @@ const formatOutput = result => {
     if (error.length !== 0) {
       const arrayLine = error.split(':');
       const errorObject = {};
-      errorObject.filename = arrayLine[0];
-      errorObject.row = arrayLine[1];
-      errorObject.column = arrayLine[2];
-      errorObject.reason = arrayLine[3].trim();
+      errorObject.filename = arrayLine.slice(0, -3).join(':');
+      errorObject.row = arrayLine[arrayLine.length - 3];
+      errorObject.column = arrayLine[arrayLine.length - 2];
+      errorObject.reason = arrayLine[arrayLine.length - 1].trim();
       allErrors.push(errorObject);
     }
   });


### PR DESCRIPTION
Properly split flake8 error messages that contain a colon in the filepath (e.g. C:\module.py).